### PR TITLE
Add link to create new repo using template

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is a minimal [Next.js](https://nextjs.org) starter template preconfigured w
 
 ### GitHub Template
 
-Create a repo from this template on GitHub.
+[Create a repo from this template on GitHub](https://github.com/mrchriscarpenter/next-starter/generate).
 
 ### Install NPM Packages
 


### PR DESCRIPTION
Update `README.md` to include a link to generate a new repository using the `next-starter` project as a template in GitHub.